### PR TITLE
Feature/miya/header: ヘッダーカートアイコンにバッジ（個数表示）を追加

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,9 +2,13 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import headerLogo from '../assets/headerLogo.svg';
 import shopIcon from '../assets/shopIcon.png';
+import { useCart } from '../context/CartContext';
 import "../pages/css/Header.css"
 
 export default function Header() {
+  const { cartItems } = useCart();
+  const totalCount = cartItems.reduce((sum, item) => sum + item.quantity, 0);
+
   return (
     <header>
       <div className="header">
@@ -12,7 +16,14 @@ export default function Header() {
         <ul className="headerUl">
           <li><Link to="/products">商品一覧</Link></li>
           <li><Link to="/recipes">レシピ</Link></li>
-          <li><Link to="/cart"><img src={shopIcon} alt="かご" /></Link></li>
+          <li>
+            <Link to="/cart" className="header-cart-link">
+              <img src={shopIcon} alt="かご" />
+              {totalCount > 0 && (
+                <span className="header-cart-badge">{totalCount}</span>
+              )}
+            </Link>
+          </li>
         </ul>
       </div>
     </header>

--- a/src/pages/css/Header.css
+++ b/src/pages/css/Header.css
@@ -43,3 +43,27 @@ header {
 li {
   list-style: none;
 }
+
+.header-cart-link {
+  position: relative;
+  display: block;
+}
+
+.header-cart-badge {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  background-color: white;
+  color: black;
+  font-weight: bold;
+  font-size: 16px;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 3px;
+  border: 2px solid black;
+}


### PR DESCRIPTION
## 概要
ヘッダーのショッピングカートアイコンに、カート内の商品合計個数をバッジで表示する機能を追加しました。

## 変更内容

### `src/components/Header.jsx`
- `useCart` フックをインポートし、`cartItems` から合計個数（`totalCount`）を計算
- `totalCount > 0` のときのみカートアイコン右上にバッジを表示
- カートリンクに `header-cart-link` クラスを追加（バッジ位置決めの基準）

### `src/pages/css/Header.css`
- `.header-cart-link`: `position: relative` でバッジの絶対位置の基準を設定
- `.header-cart-badge`: 円形（20×20px）・白背景・黒文字・黒枠のバッジスタイル

## 動作仕様
- カートに商品が入っている場合のみバッジが表示される
- バッジの数字はカート内の全商品の数量合計（CartContext の `cartItems` と連動）
- 商品追加・削除・数量変更でリアルタイムに更新される